### PR TITLE
검색어를 썻다 지웠을 때 search 쿼리파람이 남아있던 이슈를 해결한다

### DIFF
--- a/src/components/Idea/IdeaCardContainer/index.tsx
+++ b/src/components/Idea/IdeaCardContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import IdeaCard from '@src/components/Idea/IdeaCard';
 import styles from './IdeaCardContainer.module.scss';
 import { useReadIdeas } from '@src/hooks/useIdeaQuery';
@@ -11,6 +11,20 @@ import Typography from '@src/components/common/Typography';
 const IdeaCardContainer = () => {
   const target = useRef<HTMLDivElement | null>(null);
   const idea = useIdeaState();
+
+  const handleDeleteQueryKey = useCallback(() => {
+    const ideaCopy = { ...idea };
+    if (!ideaCopy?.isDone) {
+      delete ideaCopy?.isDone;
+    }
+
+    if (ideaCopy?.search?.length === 0) {
+      delete ideaCopy?.search;
+    }
+
+    return ideaCopy;
+  }, [idea]);
+
   const {
     data: infiniteData,
     fetchNextPage,
@@ -19,7 +33,8 @@ const IdeaCardContainer = () => {
     isFetchingNextPage,
     isFetchedAfterMount,
     // TODO: undefined는 isDone 프로퍼티 삭제를 위한 방법 => 좀 더 나은 방법을 생각해보기
-  } = useReadIdeas({ ...idea, isDone: idea.isDone ? true : undefined });
+  } = useReadIdeas(handleDeleteQueryKey());
+
   const handleInfiniteFetch = useThrottle(() => {
     fetchNextPage();
   }, 100);

--- a/src/components/SideList/index.tsx
+++ b/src/components/SideList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useCallback } from 'react';
 import Masonry from 'react-masonry-css';
 
 import styles from './SideList.module.scss';
@@ -20,6 +20,20 @@ const BREAKPOINT_COLS = {
 const SideList = () => {
   const target = useRef<HTMLDivElement | null>(null);
   const side = useSideState();
+
+  const handleDeleteQueryKey = useCallback(() => {
+    const sideCopy = { ...side };
+    if (!sideCopy?.isRecruiting) {
+      delete sideCopy?.isRecruiting;
+    }
+
+    if (sideCopy?.search?.length === 0) {
+      delete sideCopy?.search;
+    }
+
+    return sideCopy;
+  }, [side]);
+
   const {
     data: infiniteData,
     fetchNextPage,
@@ -27,10 +41,7 @@ const SideList = () => {
     isLoading,
     isFetchingNextPage,
     isFetchedAfterMount,
-  } = useReadSides({
-    ...side,
-    isRecruiting: side.isRecruiting ? true : undefined,
-  });
+  } = useReadSides(handleDeleteQueryKey());
 
   const handleInfiniteFetch = useThrottle(() => {
     fetchNextPage();

--- a/src/models.ts
+++ b/src/models.ts
@@ -74,10 +74,9 @@ export type SideParams = {
   category: string[];
   organization: number[];
   skill: number[];
-  // undefined 는 쿼리 파람 요청시 프로퍼티 삭제를 위해서 사용되어짐
-  isRecruiting: boolean | undefined;
+  isRecruiting?: boolean;
   page: number;
-  search: string[];
+  search?: string[];
   size: number;
   sort:
     | 'createdDate,asc'

--- a/src/pages/IdeaPage/index.tsx
+++ b/src/pages/IdeaPage/index.tsx
@@ -104,7 +104,14 @@ const IdeaPage = ({ handleToTop }: IdeaPageProps) => {
               )}
               placeholder="검색어를 입력해주세요"
               onChange={(e) =>
-                dispatch(setIdea({ search: e.target.value.split(' ') }))
+                dispatch(
+                  setIdea({
+                    search:
+                      e.target.value.length > 0
+                        ? e.target.value.split(' ')
+                        : [],
+                  }),
+                )
               }
               value={search?.join(' ')}
               onFocus={() => {

--- a/src/pages/SidePage/index.tsx
+++ b/src/pages/SidePage/index.tsx
@@ -134,7 +134,14 @@ const SidePage = ({ handleToTop }: SidePageProps) => {
               )}
               placeholder="검색어를 입력해주세요"
               onChange={(e) =>
-                dispatch(setSide({ search: e.target.value.split(' ') }))
+                dispatch(
+                  setSide({
+                    search:
+                      e.target.value.length > 0
+                        ? e.target.value.split(' ')
+                        : [],
+                  }),
+                )
               }
               onFocus={() => {
                 setIsFilterOpen(false);

--- a/src/store/ideaSlice.ts
+++ b/src/store/ideaSlice.ts
@@ -2,8 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export type IdeaParams = {
   search?: string[];
-  // undefined 는 쿼리 파람 요청시 프로퍼티 삭제를 위해서 사용되어짐
-  isDone?: boolean | undefined;
+  isDone?: boolean;
   sort?:
     | 'createdDate,asc'
     | 'favoriteCount,asc'


### PR DESCRIPTION
## Summary

## Detail
* 기존에 조건에 따라 필드에 udefined를 주는 식으로 필드 삭제를 했던 부분을 delete로 변경
* e.target.value.length 가 0인경우 빈배열을 주도록 함

## Issue
